### PR TITLE
Ignore Visual Studio Code config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /public/
 /tags
 /webpack-assets.json
+.vscode


### PR DESCRIPTION
Some people use the [Visual Studio Code](https://github.com/Microsoft/vscode) editor, which writes a `.vscode` directory relative to each project, containing the specific configuration for the project.

This patch simply ignores this dir.
