### PR TITLE
Fix lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:app-server": "NODE_ENV=development PORT=2030 node index.js",
     "dev:webpack-dev-server": "WEBPACK_PORT=2031 babel-node src/server/webpack-dev-server.js",
     "dev:prod-api": "API_URL=https://api.openfisca.fr npm run dev",
-    "linter": "eslint --ext .js,.jsx .",
+    "lint": "eslint --ext .js,.jsx .",
     "start": "NODE_ENV=production PORT=2030 node index.js"
   },
   "repository": {

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -2,7 +2,6 @@ import {Link} from "react-router"
 import React, {PropTypes} from "react"
 
 import BreadCrumb from "../breadcrumb"
-import ExternalLink from "../external-link"
 
 
 const HomePage = React.createClass({


### PR DESCRIPTION
The "linter" npm script was renamed to "lint" to follow the conventions used in the NodeJS community.

