### PR TITLE
Do not log config at application start

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,5 +4,4 @@ if (process.env.NODE_ENV === "production") {
     configFilename += '.' + (process.env.COUNTRY_PRODUCTION_CONFIG || "france")
 }
 const config = require("../config/" + configFilename).default
-console.log('config', config)
 export default config


### PR DESCRIPTION
Configuration has no reason to be printed.
