### PR TITLE
Add continuous integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev:webpack-dev-server": "WEBPACK_PORT=2031 babel-node src/server/webpack-dev-server.js",
     "dev:prod-api": "API_URL=https://api.openfisca.fr npm run dev",
     "lint": "eslint --ext .js,.jsx .",
-    "start": "NODE_ENV=production PORT=2030 node index.js"
+    "start": "NODE_ENV=production PORT=2030 node index.js",
+    "test": "npm run lint && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Connected to #37 

CircleCI infers that this is a NodeJS project, so for now there is no need to commit a `circle.yml` file. Providing `npm test` in `package.json` suffices.