### PR TITLE
Update dependencies before build in deployment script

### DIFF
--- a/deploy_prod.sh
+++ b/deploy_prod.sh
@@ -5,6 +5,7 @@ pwd
 git branch
 
 git pull
+npm install
 npm run build
 
 echo "Restarting legislation-explorer service..."


### PR DESCRIPTION
This improves resilience of continuous deployment script (introduced in #50), in the case there is a need to update the dependencies.

> I could have added a `npm install` line in [deploy_prod.sh](https://github.com/openfisca/legislation-explorer/blob/master/deploy_prod.sh) before `npm run build`, but the `prebuild` script is less specific.