### PR TITLE
Make Parameter and Scale description not required anymore

### DIFF
--- a/src/app-prop-types.js
+++ b/src/app-prop-types.js
@@ -25,7 +25,7 @@ const unit = PropTypes.oneOf([
 
 const parameter = PropTypes.shape({
   "@type": PropTypes.oneOf(["Parameter"]).isRequired,
-  description: PropTypes.string.isRequired,
+  description: PropTypes.string,
   format: PropTypes.oneOf([
     "boolean",
     "float",
@@ -51,7 +51,7 @@ const scale = PropTypes.shape({
       end_line_number: PropTypes.number,
     }),
   ),
-  description: PropTypes.string.isRequired,
+  description: PropTypes.string,
   unit,
   // Introspection (optional: values can be generated programmatically)
   xml_file_path: PropTypes.string,


### PR DESCRIPTION
Precedes #59 

In order to keep PRs atomic, I create this one dedicated to fix a warning I didn't see during development:

```
[0] Warning: Failed prop type: Invalid prop `parameters[749]` supplied to `HomePage`.
[0]     in HomePage (created by RouterContext)
[0]     in RouterContext
[0]     in IntlProvider
[0] Warning: Failed prop type: Invalid prop `parameters[749]` supplied to `App`.
[0]     in App (created by RouterContext)
[0]     in RouterContext
[0]     in IntlProvider
```

The prop-types system is specific to React and overlaps with a type-checking system; but it's here so better fix it.