### PR TITLE
Replace errors emailing by logging

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -1,6 +1,8 @@
 // App config the for development environment.
 // Do not require this directly. Use ./src/config instead.
 
+import winston from "winston"
+
 
 const HOST = process.env.HOST || "localhost",
   apiBaseUrl = process.env.API_URL || `http://${HOST}:5000`,
@@ -8,7 +10,12 @@ const HOST = process.env.HOST || "localhost",
   gitWebpageUrl = "https://github.com/openfisca/legislation-explorer",
   piwikConfig = null,
   useCommitReferenceFromApi = true,
-  websiteUrl = "https://www.openfisca.fr/"
+  websiteUrl = "https://www.openfisca.fr/",
+  winstonConfig = {
+    transports: [
+      new (winston.transports.Console)({timestamp: true}),
+    ]
+  }
 
 
 export default {
@@ -18,4 +25,5 @@ export default {
   piwikConfig,
   useCommitReferenceFromApi,
   websiteUrl,
+  winstonConfig,
 }

--- a/config/production.france.js
+++ b/config/production.france.js
@@ -1,6 +1,9 @@
 // App config the for production environment.
 // Do not require this directly. Use ./src/config instead.
 
+import winston from "winston"
+
+
 const  apiBaseUrl = process.env.API_URL || `https://api-test.openfisca.fr`,
   gitHubProject = "openfisca/openfisca-france",
   gitWebpageUrl = "https://github.com/openfisca/legislation-explorer",
@@ -10,7 +13,12 @@ const  apiBaseUrl = process.env.API_URL || `https://api-test.openfisca.fr`,
     trackErrors: true
   },
   useCommitReferenceFromApi = true,
-  websiteUrl = "https://www.openfisca.fr/"
+  websiteUrl = "https://www.openfisca.fr/",
+  winstonConfig = {
+    transports: [
+      new (winston.transports.Console)({timestamp: true}),
+    ]
+  }
 
 
 export default {
@@ -20,4 +28,5 @@ export default {
   piwikConfig,
   useCommitReferenceFromApi,
   websiteUrl,
+  winstonConfig,
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-intl": "^2.1.2",
     "react-router": "^2.4.1",
     "serve-favicon": "^2.3.0",
-    "swagger-ui": "^3.0.12"
+    "swagger-ui": "3.0.12",
   },
   "devDependencies": {
     "babel-core": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "copy-webpack-plugin": "^3.0.1",
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",
+    "json-loader": "^0.5.4",
     "piping": "^1.0.0-rc.3",
     "react-transform-hmr": "^1.0.4",
     "watai": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-router": "^2.4.1",
     "serve-favicon": "^2.3.0",
     "swagger-ui": "3.0.12",
+    "winston": "^2.3.1"
   },
   "devDependencies": {
     "babel-core": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "bootstrap": "^3.3.5",
     "classnames": "^2.2.5",
     "diacritics": "^1.3.0",
-    "emailjs": "^1.0.5",
     "express": "^4.12.4",
     "intl": "^1.2.4",
     "intl-locales-supported": "^1.0.0",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -24,8 +24,11 @@ function startServer(state) {
   server.use((err, req, res, next) => {
     winston.error(req.method + " " + req.url, {error: err})
     if (server.get("env") === "production") {
-      res.status(500).send("Something unexpected happened, sorry. The error has been logged.\n" +
-        "Details : " + Date().toISOString() + ", " + err.stack
+      res.status(500).send(
+        "<pre>"
+        + "Something unexpected happened, sorry. The error has been logged.\n"
+        + "Details : " + new Date().toISOString() + ", " + err.stack
+        + "</pre>"
       )
     } else {
       next(err)

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -22,9 +22,11 @@ function startServer(state) {
 
   // Generic server errors (e.g. not caught by components)
   server.use((err, req, res, next) => {
-    winston.error("Error on request " + req.method + " " + req.url + '\n'  + err.stack)
+    winston.error(req.method + " " + req.url, {error: err})
     if (server.get("env") === "production") {
-      res.status(500).send("Something unexpected happened, sorry. The error has been logged.")
+      res.status(500).send("Something unexpected happened, sorry. The error has been logged.\n" +
+        "Details : " + Date().toISOString() + ", " + err.stack
+      )
     } else {
       next(err)
     }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,4 +1,3 @@
-import emailjs from "emailjs"
 import express from "express"
 import {assoc, map} from "ramda"
 import favicon from "serve-favicon"

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -25,10 +25,11 @@ function startServer(state) {
     winston.error(req.method + " " + req.url, {error: err})
     if (server.get("env") === "production") {
       res.status(500).send(
-        "<pre>"
-        + "Something unexpected happened, sorry. The error has been logged.\n"
-        + "Details : " + new Date().toISOString() + ", " + err.stack
-        + "</pre>"
+        '<h1>Error: ' + err.message + '</h1>'
+        + '<p>This error has been logged at ' + new Date().toISOString() + '.</p>'
+        + '<p>If this happens often, please <a href="https://github.com/openfisca/legislation-explorer/issues/new?title=' + err.message + '">open an issue</a>.</p>'
+        + '<h2>Technical details</h2>'
+        + '<pre>' + err.stack + '</pre>'
       )
     } else {
       next(err)

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -10,9 +10,10 @@ import {fetchParameters, fetchVariables, fetchSwagger} from "../webservices"
 import config from "../config"
 
 
-function startServer(state) {
-  winston.configure(config.winstonConfig);
+winston.configure(config.winstonConfig);
 
+
+function startServer(state) {
   const server = express()
   server.use(favicon(path.resolve(__dirname, "../assets/favicon.ico")))
   server.use(express.static(path.resolve(__dirname, "../../public")))

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,9 +7,12 @@ import winston from "winston"
 import handleRender from "./render"
 import {addNormalizedDescription} from "../search"
 import {fetchParameters, fetchVariables, fetchSwagger} from "../webservices"
+import config from "../config"
 
 
 function startServer(state) {
+  winston.configure(config.winstonConfig);
+
   const server = express()
   server.use(favicon(path.resolve(__dirname, "../assets/favicon.ico")))
   server.use(express.static(path.resolve(__dirname, "../../public")))

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -53,6 +53,10 @@ module.exports = {
           ],
         },
         test: /\.(js|jsx)$/,
+      },
+      {
+        loader: 'json-loader',
+        test: /\.json$/,
       }
     ],
   },

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -33,6 +33,11 @@ module.exports = {
         loader: "babel",
         test: /\.(js|jsx)$/,
       },
+      {
+        loader: 'json-loader',
+        test: /\.json$/,
+        exclude: /(node_modules|public)/,
+      }
     ],
   },
   resolve: {

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -36,7 +36,6 @@ module.exports = {
       {
         loader: 'json-loader',
         test: /\.json$/,
-        exclude: /(node_modules|public)/,
       }
     ],
   },


### PR DESCRIPTION
Connected to #86.

To test the logging, I added some code intended to fail here : https://github.com/openfisca/legislation-explorer/blob/master/src/server/render.jsx#L15 :
```js
    var a
    a.b
```

Console output is : 
```
[0] Server listening at http://localhost:2030/
[0] error: Error on request GET /
[0] TypeError: Cannot read property 'b' of undefined
[0]     at /data/projects/openfisca/legislation-explorer/src/server/render.jsx:16:5
[0]     at Layer.handle [as handle_request] (/data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/layer.js:95:5)
[0]     at trim_prefix (/data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/index.js:317:13)
[0]     at /data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/index.js:284:7
[0]     at Function.process_params (/data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/index.js:335:12)
[0]     at next (/data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/index.js:275:10)
[0]     at SendStream.error (/data/projects/openfisca/legislation-explorer/node_modules/serve-static/index.js:121:7)
[0]     at emitOne (events.js:96:13)
[0]     at SendStream.emit (events.js:188:7)
[0]     at SendStream.error (/data/projects/openfisca/legislation-explorer/node_modules/send/index.js:282:17)
[0] TypeError: Cannot read property 'b' of undefined
[0]     at /data/projects/openfisca/legislation-explorer/src/server/render.jsx:16:5
[0]     at Layer.handle [as handle_request] (/data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/layer.js:95:5)
[0]     at trim_prefix (/data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/index.js:317:13)
[0]     at /data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/index.js:284:7
[0]     at Function.process_params (/data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/index.js:335:12)
[0]     at next (/data/projects/openfisca/legislation-explorer/node_modules/express/lib/router/index.js:275:10)
[0]     at SendStream.error (/data/projects/openfisca/legislation-explorer/node_modules/serve-static/index.js:121:7)
[0]     at emitOne (events.js:96:13)
[0]     at SendStream.emit (events.js:188:7)
[0]     at SendStream.error (/data/projects/openfisca/legislation-explorer/node_modules/send/index.js:282:17)
```

The stack is logged twice.

Is there a way to automate this test ?