### PR TITLE
Upgrade webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "type": "git",
     "url": "https://github.com/openfisca/legislation-explorer.git"
   },
-  "author": "Christophe Benz <christophe.benz@data.gouv.fr>",
+  "author": "OpenFisca <contact@openfisca.fr>",
   "license": "AGPLv3+",
   "dependencies": {
     "babel-cli": "^6.11.4",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "OpenFisca - Legislation Explorer",
   "scripts": {
-    "build": "webpack --config ./webpack.config.prod.babel.js",
-    "build:tunisia": "COUNTRY_PRODUCTION_CONFIG=tunisia webpack --config ./webpack.config.prod.babel.js",
+    "build": "webpack --config ./webpack.config.prod.babel.js --progress",
+    "build:tunisia": "COUNTRY_PRODUCTION_CONFIG=tunisia webpack --config ./webpack.config.prod.babel.js --progress",
     "clean": "rm -rf public",
     "dev": "concurrently --kill-others 'npm run dev:app-server' 'npm run dev:webpack-dev-server'",
     "dev:app-server": "NODE_ENV=development PORT=2030 node index.js",
@@ -57,8 +57,8 @@
     "piping": "^1.0.0-rc.3",
     "react-transform-hmr": "^1.0.4",
     "watai": "^0.7.0",
-    "webpack": "^1.9.11",
-    "webpack-dev-server": "^1.9.0",
+    "webpack": "^2.0.0",
+    "webpack-dev-server": "^2.0.0",
     "webpack-error-notification": "^0.1.4"
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-intl": "^2.1.2",
     "react-router": "^2.4.1",
     "serve-favicon": "^2.3.0",
-    "swagger-ui": "^3.0.12"
+    "swagger-ui": "3.0.12"
   },
   "devDependencies": {
     "babel-core": "^6.9.0",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -37,24 +37,26 @@ module.exports = {
     fs: 'empty'
   },
   module: {
-    loaders: [
+    rules: [
       {
-        exclude: /(node_modules|public)/,
-        loader: "babel-loader",
-        query: {
-          "plugins": [
-            ["react-transform", {
-              "transforms": [{
-                "transform": "react-transform-hmr",
-                "imports": ["react"],
-                "locals": ["module"],
-              }],
-            }],
-          ],
-        },
         test: /\.(js|jsx)$/,
+        exclude: /(node_modules|public)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            plugins: [
+              ["react-transform", {
+                "transforms": [{
+                  "transform": "react-transform-hmr",
+                  "imports": ["react"],
+                  "locals": ["module"],
+                }],
+              }],
+            ],
+          }
+        }
       }
-    ],
+    ]
   },
   resolve: {
     extensions: [".js", ".jsx"],

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -65,6 +65,11 @@ module.exports = {
 
     new webpack.NoEmitOnErrorsPlugin(),
 
+    // Avoid erros about YAML-JS
+    new webpack.ProvidePlugin({
+      'require.extensions': null
+    }),
+
     // print a webpack progress
     new webpack.ProgressPlugin((percentage) => {
       if (percentage === 1) {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -40,7 +40,7 @@ module.exports = {
     loaders: [
       {
         exclude: /(node_modules|public)/,
-        loader: "babel",
+        loader: "babel-loader",
         query: {
           "plugins": [
             ["react-transform", {
@@ -57,14 +57,13 @@ module.exports = {
     ],
   },
   resolve: {
-    extensions: ["", ".js", ".jsx"],
+    extensions: [".js", ".jsx"],
   },
-  progress: true,
   plugins: [
     // hot reload
     new webpack.HotModuleReplacementPlugin(),
 
-    new webpack.NoErrorsPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
 
     // print a webpack progress
     new webpack.ProgressPlugin((percentage) => {

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -27,13 +27,15 @@ module.exports = {
     fs: 'empty'
   },
   module: {
-    loaders: [
+    rules: [
       {
-        exclude: /(node_modules|public)/,
-        loader: "babel-loader",
         test: /\.(js|jsx)$/,
-      },
-    ],
+        exclude: /(node_modules|public)/,
+        use: {
+          loader: 'babel-loader',
+        }
+      }
+    ]
   },
   resolve: {
     extensions: [".js", ".jsx"],

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -30,15 +30,14 @@ module.exports = {
     loaders: [
       {
         exclude: /(node_modules|public)/,
-        loader: "babel",
+        loader: "babel-loader",
         test: /\.(js|jsx)$/,
       },
     ],
   },
   resolve: {
-    extensions: ["", ".js", ".jsx"],
+    extensions: [".js", ".jsx"],
   },
-  progress: true,
   plugins: [
 
     // set global vars


### PR DESCRIPTION
Problem encountered trying to upgrade to `wepack2`: 

I start the server with `npm run dev:prod-api`. 

I get a few warnings, but the server starts correctly:
```
DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56.
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
[0] Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
[0] Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class
```
However, when I open a page, I get the error in the console:

```
yaml.js:263 Uncaught Error: Cannot find module "."
    at webpackMissingModule (yaml.js:263)
    at Object.defineProperty.value (yaml.js:263)
    at __webpack_require__ (bootstrap b3622f4…:659)
    at fn (bootstrap b3622f4…:85)
    at r (swagger-ui.js:1)
    at Object.<anonymous> (swagger-ui.js:1)
    at __webpack_require__ (bootstrap b3622f4…:659)
    at fn (bootstrap b3622f4…:85)
    at Object.<anonymous> (swagger.jsx:2)
```
And the JS of the page doesn't work properly.

`yaml.js` is a sub-sub dependency, that we probably don't use at all 😞 .
