### PR TITLE
Enhance 404 pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,25 @@ To maintain the legislation at its latest version, you can check the [auto-updat
 
 > Legislation Explorer integration tests are implemented with [Watai](https://github.com/MattiSG/Watai).
 
-In order to run integration tests, please install [Selenium standalone server](http://www.seleniumhq.org/download/).
+### Install the necessary helpers
 
-Run Selenium standalone server in a terminal:
+Install [Selenium standalone server](http://www.seleniumhq.org/download/).
+
+Install Chrome WebDriver : The `tests/config.js` in this package is pre-configured to use Chrome WebDriver. 
+* Under Debian GNU/Linux install it with `apt install chromium-driver` (Chromium is the free software version of Chrome).
+* Under Mac OS X install it with `brew install chromedriver`
+    
+### Run the integration tests 
+
+- Terminal window 1 : run Selenium standalone server
 
 ```sh
-java -jar selenium-server-standalone-3.3.0.jar
+java -jar selenium-server-standalone-3.4.0.jar
 18:51:36.494 INFO - Selenium build info: version: '3.3.0', revision: 'b526bd5'
 [...]
 18:51:36.722 INFO - Selenium Server is up and running
 ```
-
-The `tests/config.js` is pre-configured to use Chrome WebDriver. Under Debian GNU/Linux install it with `apt install chromium-driver` (Chromium is the free software version of Chrome).
-
-Run Chrome WebDriver in a terminal:
+- Terminal window 2 : run Chrome WebDriver
 
 ```sh
 chromedriver
@@ -66,9 +71,9 @@ Starting ChromeDriver 2.25 (undefined) on port 9515
 Only local connections are allowed.
 ```
 
-Start the application development server if not already done (`npm run dev:prod-api`).
+- Terminal window 3 : start the application development server if not already done (`npm run dev:prod-api`).
 
-Run the integration tests:
+- Terminal window 4 : run the integration tests
 
 ```sh
 npm run test:integration

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -27,8 +27,8 @@
   "editThisFormula":"Edit this formula",
   "thisVariableJson":"Get the JSON for this variable",
   "checkChangelog":"Check the spelling of the requested URL. If this link used to work and doesn't anymore, check the {changelogURLLink}.",
-  "notParamNotVariable":"' {inputValueRef} ' is neither a parameter nor a variable in OpenFisca.",
-  "pageDoesNotExist":"The page « /{inputValueRef} » does not exist.",
+  "notParamNotVariable":"'{inputValueRef}' is neither a parameter nor a variable in OpenFisca.",
+  "pageDoesNotExist":"The page '{inputValueRef}' does not exist.",
   "backToHP":"Back to the homepage",
   "explore":"Explore OpenFisca's parameter and variable database",
   "find":"Find"

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -25,5 +25,11 @@
   "formulaNotComputableText":"not computable",
   "editThisVariable":"Edit this variable",
   "editThisFormula":"Edit this formula",
-  "thisVariableJson":"Get the JSON for this variable"
+  "thisVariableJson":"Get the JSON for this variable",
+  "checkChangelog":"Check the spelling of the requested URL. If this link used to work and doesn't anymore, check the {changelogURLLink}.",
+  "notParamNotVariable":"' {inputValueRef} ' is neither a parameter nor a variable in OpenFisca.",
+  "pageDoesNotExist":"The page « /{inputValueRef} » does not exist.",
+  "backToHP":"Back to the homepage",
+  "explore":"Explore OpenFisca's parameter and variable database",
+  "find":"Find"
 }

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -25,5 +25,11 @@
   "formulaNotComputableText":"pas calculable",
   "editThisVariable":"Modifier ces informations",
   "editThisFormula":"Modifier cette formule",
-  "thisVariableJson":"Donnée brute au format JSON"
+  "thisVariableJson":"Donnée brute au format JSON",
+  "checkChangelog":"Vérifiez l'orthographe de l'URL. Si ce lien fonctionnait et ne fonctionne plus, vérifiez le {changelogURLLink}.",
+  "notParamNotVariable":"' {inputValueRef} ' n'est ni un paramètre ni une variable d'OpenFisca.",
+  "pageDoesNotExist":"La page « /{inputValueRef} » n'existe pas.",
+  "backToHP":"Retour à l'accueil",
+  "explore":"Explorez la base de paramètres et variables OpenFisca",
+  "find":"Trouver"
 }

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -27,8 +27,8 @@
   "editThisFormula":"Modifier cette formule",
   "thisVariableJson":"Donnée brute au format JSON",
   "checkChangelog":"Vérifiez l'orthographe de l'URL. Si ce lien fonctionnait et ne fonctionne plus, vérifiez le {changelogURLLink}.",
-  "notParamNotVariable":"' {inputValueRef} ' n'est ni un paramètre ni une variable d'OpenFisca.",
-  "pageDoesNotExist":"La page « /{inputValueRef} » n'existe pas.",
+  "notParamNotVariable":"'{inputValueRef}' n'est ni un paramètre ni une variable d'OpenFisca.",
+  "pageDoesNotExist":"La page '{inputValueRef}'' n'existe pas.",
   "backToHP":"Retour à l'accueil",
   "explore":"Explorez la base de paramètres et variables OpenFisca",
   "find":"Trouver"

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -5,8 +5,8 @@ import {FormattedMessage} from "react-intl"
 
 import * as AppPropTypes from "../../app-prop-types"
 import List from "../list"
-
 import config from "../../config"
+import SearchBarComponent from "./searchbar"
 export const searchInputId = "search-input"
 
 const HomePage = React.createClass({
@@ -35,38 +35,21 @@ const HomePage = React.createClass({
   getInitialState() {
     return {inputValue: ""}
   },
-  handleClearSearchClicked() {
-    const searchQuery = ""
-    this.setState({inputValue: searchQuery})
-    this.setState({is404: false})
-    this.context.setSearchQuery(searchQuery)
-    this.context.router.push({
-      query: {q: searchQuery},
-      hash: `#${searchInputId}`,
-    })
-  },
-  handleInputChange(event) {
-    this.setState({inputValue: event.target.value})
-    this.setState({is404: false})
-    // Use scrollIntoView before pushing searchInputId in the hash, to scroll after the first character is typed.
-    this.searchInput.scrollIntoView()
-  },
-  handleSubmit(event) {
-    event.preventDefault()
-    this.context.setSearchQuery(this.state.inputValue)
-    this.context.router.push({
-      query: {q: this.state.inputValue},
-      hash: `#${searchInputId}`,
-    })
-    this.setState({is404: false})
-  },
+
   locationHasChanged(location) {
     const {router} = this.context
     const oldLocation = this.props.location
     // Check that the new location stays on the Home page, to avoid overwriting searchQuery in App state.
-    if (this._isMounted && router.isActive(oldLocation)) {
-      const searchQuery = location.query.q || ""
-      this.context.setSearchQuery(searchQuery)
+    if (this._isMounted) {
+      let searchQuery = ""
+      if (location.query.q || !location.query.is404) {
+        searchQuery = location.query.q
+      }
+
+      if(searchQuery){
+        console.log("it passed")
+        this.context.setSearchQuery(searchQuery)
+      }
       this.setState({inputValue: searchQuery})
       this.setState({is404: location.query.is404})
     }
@@ -97,35 +80,7 @@ const HomePage = React.createClass({
             </p>
           </div>
           }
-        <form onSubmit={this.handleSubmit}>
-          <div className="input-group input-group-lg" style={{margin: "2em 0"}}>
-            <input
-              autoFocus={true}
-              className="form-control"
-              id="search-input"
-              onChange={this.handleInputChange}
-              placeholder="smic, salaire net…"
-              ref={element => this.searchInput = element}
-              type="text"
-              value={inputValue}
-            />
-            <div className="input-group-btn">
-              {
-                !isEmpty(searchQuery) && (
-                  <button
-                    className="btn btn-default"
-                    onClick={this.handleClearSearchClicked}
-                    title="Effacer la recherche"
-                    type="button"
-                  >
-                    <span className="glyphicon glyphicon-remove" aria-hidden="true" />
-                  </button>
-                )
-              }
-              <button className="btn btn-primary" type="submit"><FormattedMessage id = "find"/></button>
-            </div>
-          </div>
-        </form>
+        <SearchBarComponent/>
         <section>
           {
             isEmpty(searchResults)
@@ -149,6 +104,7 @@ const SearchResults = React.createClass({
     return nextProps.searchQuery !== this.props.searchQuery
   },
   render() {
+    console.log(this.props.searchQuery)
     const {items} = this.props
     return (
       <List items={items} type="unstyled">

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -6,6 +6,7 @@ import {FormattedMessage} from "react-intl"
 import * as AppPropTypes from "../../app-prop-types"
 import List from "../list"
 
+import config from "../../config"
 export const searchInputId = "search-input"
 
 const HomePage = React.createClass({
@@ -76,7 +77,7 @@ const HomePage = React.createClass({
     const source = this.state.source
     const {searchQuery, searchResults} = this.context
     const countryPackageName = this.props.countryPackageName
-    const changelogURL = `http://www.github.com/openfisca/` + `${countryPackageName}` + `/blob/master/CHANGELOG.md`
+    const changelogURL = `https://www.github.com/${config.gitHubProject}/blob/master/CHANGELOG.md`
     return (
       <div>
         {source == "404" &&

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -75,18 +75,18 @@ const HomePage = React.createClass({
     const source = this.state.source
     const {searchQuery, searchResults} = this.context
     const countryPackageName = this.props.countryPackageName
-    const changelogURL = "http://www.github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md"
+    const changelogURL = `http://www.github.com/openfisca/` + `${countryPackageName}` + `/blob/master/CHANGELOG.md`
     return (
       <div>
-        {source == "404" ?(
+        {source == "404" &&
             <div className="alert alert-info" id="not-found">
             <h4 >
               La page « /{inputValue} » n'existe pas.
             </h4>
             <p>" {inputValue} " n'est ni un paramètre ni une variable d'OpenFisca.</p>
             <p>Vérifiez l'orthographe de l'URL. Si ce lien fonctionnait et ne fonctionne plus, vérifiez le <a href={changelogURL}>changelog</a>.</p>
-          </div>):(console.log(source))
-          }   
+          </div>
+          }
         <form onSubmit={this.handleSubmit}>
           <div className="input-group input-group-lg" style={{margin: "2em 0"}}>
             <input

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -39,7 +39,7 @@ const HomePage = React.createClass({
   locationHasChanged(location) {
     if (this._isMounted) {
       let searchQuery = ""
-      if (location.query.q || !location.query.is404) {
+      if (location.query.q) {
         searchQuery = location.query.q
       }
 

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -36,6 +36,7 @@ const HomePage = React.createClass({
   handleClearSearchClicked() {
     const searchQuery = ""
     this.setState({inputValue: searchQuery})
+    this.setState({source: "search"})
     this.context.setSearchQuery(searchQuery)
     this.context.router.push({
       query: {q: searchQuery},
@@ -44,6 +45,7 @@ const HomePage = React.createClass({
   },
   handleInputChange(event) {
     this.setState({inputValue: event.target.value})
+    this.setState({source: "search"})
     // Use scrollIntoView before pushing searchInputId in the hash, to scroll after the first character is typed.
     this.searchInput.scrollIntoView()
   },
@@ -54,6 +56,7 @@ const HomePage = React.createClass({
       query: {q: this.state.inputValue},
       hash: `#${searchInputId}`,
     })
+    this.setState({source: "search"})
   },
   locationHasChanged(location) {
     const {router} = this.context
@@ -61,21 +64,35 @@ const HomePage = React.createClass({
     // Check that the new location stays on the Home page, to avoid overwriting searchQuery in App state.
     if (this._isMounted && router.isActive(oldLocation)) {
       const searchQuery = location.query.q || ""
+      const sourceOfQuery = location.query.source || ""
       this.context.setSearchQuery(searchQuery)
       this.setState({inputValue: searchQuery})
+      this.setState({source: sourceOfQuery})
     }
   },
   render() {
-    const {inputValue} = this.state
+    const inputValue = this.state.inputValue
+    const source = this.state.source
     const {searchQuery, searchResults} = this.context
+    const countryPackageName = this.props.countryPackageName
+    const changelogURL = "http://www.github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md"
     return (
       <div>
+        {source == "404" ?(
+            <div className="alert alert-info" id="not-found">
+            <h4 >
+              La page « /{inputValue} » n'existe pas.
+            </h4>
+            <p>" {inputValue} " n'est ni un paramètre ni une variable d'OpenFisca.</p>
+            <p>Vérifiez l'orthographe de l'URL. Si ce lien fonctionnait et ne fonctionne plus, vérifiez le <a href={changelogURL}>changelog</a>.</p>
+          </div>):(console.log(source))
+          }   
         <form onSubmit={this.handleSubmit}>
           <div className="input-group input-group-lg" style={{margin: "2em 0"}}>
             <input
               autoFocus={true}
               className="form-control"
-              id={searchInputId}
+              id="search-input"
               onChange={this.handleInputChange}
               placeholder="smic, salaire net…"
               ref={element => this.searchInput = element}

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -38,7 +38,7 @@ const HomePage = React.createClass({
   handleClearSearchClicked() {
     const searchQuery = ""
     this.setState({inputValue: searchQuery})
-    this.setState({source: "search"})
+    this.setState({is404: false})
     this.context.setSearchQuery(searchQuery)
     this.context.router.push({
       query: {q: searchQuery},
@@ -47,7 +47,7 @@ const HomePage = React.createClass({
   },
   handleInputChange(event) {
     this.setState({inputValue: event.target.value})
-    this.setState({source: "search"})
+    this.setState({is404: false})
     // Use scrollIntoView before pushing searchInputId in the hash, to scroll after the first character is typed.
     this.searchInput.scrollIntoView()
   },
@@ -58,7 +58,7 @@ const HomePage = React.createClass({
       query: {q: this.state.inputValue},
       hash: `#${searchInputId}`,
     })
-    this.setState({source: "search"})
+    this.setState({is404: false})
   },
   locationHasChanged(location) {
     const {router} = this.context
@@ -66,29 +66,28 @@ const HomePage = React.createClass({
     // Check that the new location stays on the Home page, to avoid overwriting searchQuery in App state.
     if (this._isMounted && router.isActive(oldLocation)) {
       const searchQuery = location.query.q || ""
-      const sourceOfQuery = location.query.source || ""
       this.context.setSearchQuery(searchQuery)
       this.setState({inputValue: searchQuery})
-      this.setState({source: sourceOfQuery})
+      this.setState({is404: location.query.is404})
     }
   },
+
   render() {
     const inputValue = this.state.inputValue
-    const source = this.state.source
+    const is404 = this.state.is404
     const {searchQuery, searchResults} = this.context
-    const countryPackageName = this.props.countryPackageName
     const changelogURL = `https://www.github.com/${config.gitHubProject}/blob/master/CHANGELOG.md`
     return (
       <div>
-        {source == "404" &&
+        {is404 &&
             <div className="alert alert-info" id="not-found">
             <h4 >
               <FormattedMessage id = "pageDoesNotExist" values=
-              {{inputValueRef:`${inputValue}`}}/>
+              {{inputValueRef: inputValue}}/>
             </h4>
             <p>
               <FormattedMessage id = "notParamNotVariable" values=
-              {{inputValueRef:`${inputValue}`}}/>
+              {{inputValueRef: inputValue}}/>
             </p>
             <p>
               <FormattedMessage id = "checkChangelog" values=

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -1,6 +1,7 @@
 import {isEmpty} from "ramda"
 import React, {PropTypes} from "react"
 import {Link, locationShape, routerShape} from "react-router"
+import {FormattedMessage} from "react-intl"
 
 import * as AppPropTypes from "../../app-prop-types"
 import List from "../list"
@@ -81,10 +82,19 @@ const HomePage = React.createClass({
         {source == "404" &&
             <div className="alert alert-info" id="not-found">
             <h4 >
-              La page « /{inputValue} » n'existe pas.
+              <FormattedMessage id = "pageDoesNotExist" values=
+              {{inputValueRef:`${inputValue}`}}/>
             </h4>
-            <p>" {inputValue} " n'est ni un paramètre ni une variable d'OpenFisca.</p>
-            <p>Vérifiez l'orthographe de l'URL. Si ce lien fonctionnait et ne fonctionne plus, vérifiez le <a href={changelogURL}>changelog</a>.</p>
+            <p>
+              <FormattedMessage id = "notParamNotVariable" values=
+              {{inputValueRef:`${inputValue}`}}/>
+            </p>
+            <p>
+              <FormattedMessage id = "checkChangelog" values=
+              {{changelogURLLink:
+                <a href = {changelogURL} target = "_blank">changelog</a>
+              }}/>
+            </p>
           </div>
           }
         <form onSubmit={this.handleSubmit}>
@@ -112,7 +122,7 @@ const HomePage = React.createClass({
                   </button>
                 )
               }
-              <button className="btn btn-primary" type="submit">Trouver</button>
+              <button className="btn btn-primary" type="submit"><FormattedMessage id = "find"/></button>
             </div>
           </div>
         </form>

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -76,7 +76,7 @@ const HomePage = React.createClass({
             </p>
           </div>
           }
-        <SearchBarComponent/>
+        <SearchBarComponent initialValue={inputValue}/>
         <section>
           {
             isEmpty(searchResults)

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -100,7 +100,6 @@ const SearchResults = React.createClass({
     return nextProps.searchQuery !== this.props.searchQuery
   },
   render() {
-    console.log(this.props.searchQuery)
     const {items} = this.props
     return (
       <List items={items} type="unstyled">

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -37,17 +37,13 @@ const HomePage = React.createClass({
   },
 
   locationHasChanged(location) {
-    const {router} = this.context
-    const oldLocation = this.props.location
-    // Check that the new location stays on the Home page, to avoid overwriting searchQuery in App state.
     if (this._isMounted) {
       let searchQuery = ""
       if (location.query.q || !location.query.is404) {
         searchQuery = location.query.q
       }
 
-      if(searchQuery){
-        console.log("it passed")
+      if (searchQuery) {
         this.context.setSearchQuery(searchQuery)
       }
       this.setState({inputValue: searchQuery})

--- a/src/components/pages/not-found.jsx
+++ b/src/components/pages/not-found.jsx
@@ -2,6 +2,7 @@ import { Link, locationShape, routerShape } from "react-router"
 import React, {PropTypes} from "react"
 import DocumentTitle from "react-document-title"
 import {FormattedMessage} from "react-intl"
+import config from "../../config"
 
 const NotFoundPage = React.createClass({
   contextTypes: {
@@ -29,7 +30,7 @@ const NotFoundPage = React.createClass({
   render() {
     const {pathname} = this.props.location
     const countryPackageName = this.props.countryPackageName
-    const changelogURL = `http://www.github.com/openfisca/${countryPackageName}/blob/master/CHANGELOG.md`
+    const changelogURL = `https://www.github.com/${config.gitHubProject}/blob/master/CHANGELOG.md`
     return (
       <DocumentTitle title={`Page non trouvée - Explorateur de la législation`}>
         <div>

--- a/src/components/pages/not-found.jsx
+++ b/src/components/pages/not-found.jsx
@@ -2,25 +2,53 @@ import {Link, locationShape} from "react-router"
 import React, {PropTypes} from "react"
 import DocumentTitle from "react-document-title"
 
+import HomePage from "./home"
 
 const NotFoundPage = React.createClass({
   propTypes: {
     location: locationShape.isRequired,
     message: PropTypes.string,
+    countryPackageName: PropTypes.string,
+  handleSubmit(event) {
+    return <HomePage/>
   },
   render() {
     const {pathname} = this.props.location
     const message = this.props.message || `La page « ${pathname} » n'existe pas.`
+    const countryPackageName = this.props.countryPackageName
+    const changelogURL = `http://www.github.com/openfisca/${countryPackageName}/blob/master/CHANGELOG.md`
     return (
       <DocumentTitle title={`Page non trouvée - Explorateur de la législation`}>
         <div>
           <div className="page-header">
             <h1>Page non trouvée</h1>
+            <h1>La page « {pathname} » n'existe pas.</h1>
           </div>
           <div className="alert alert-danger">
             {message}
+          <div className="alert alert-info">
+            <p>{message}</p>
+            <p>Vérifiez l'orthographe de l'URL. Si ce lien fonctionnait et ne fonctionne plus, vérifiez le <a href={changelogURL}>changelog</a>.</p>
           </div>
           <Link className="btn btn-default" to="/">Retour à l'accueil</Link>
+          <hr></hr>
+          <h3>Explorez la base de paramètres et variables OpenFisca</h3>
+          <div>
+          <form onSubmit={this.handleSubmit}>
+            <div className="input-group input-group-lg" style={{margin: "2em 0"}}>
+              <input
+                autoFocus={true}
+                className="form-control"
+                id="searchInputId"
+                placeholder="smic, salaire net…"
+                type="text"
+              />
+              <div className="input-group-btn">
+                <button className="btn btn-primary" href="http://www.openfisca.com">Trouver</button>
+              </div>
+            </div>
+          </form>
+        </div>
         </div>
       </DocumentTitle>
     )

--- a/src/components/pages/not-found.jsx
+++ b/src/components/pages/not-found.jsx
@@ -1,6 +1,7 @@
 import { Link, locationShape, routerShape } from "react-router"
 import React, {PropTypes} from "react"
 import DocumentTitle from "react-document-title"
+import {FormattedMessage} from "react-intl"
 
 const NotFoundPage = React.createClass({
   contextTypes: {
@@ -27,23 +28,27 @@ const NotFoundPage = React.createClass({
 
   render() {
     const {pathname} = this.props.location
-    const message = this.props.message || `La page « ${pathname} » n'existe pas.`
     const countryPackageName = this.props.countryPackageName
     const changelogURL = `http://www.github.com/openfisca/${countryPackageName}/blob/master/CHANGELOG.md`
     return (
       <DocumentTitle title={`Page non trouvée - Explorateur de la législation`}>
         <div>
           <div className="page-header">
-            <h1>La page « {pathname} » n'existe pas.</h1>
+            <h1>
+            <FormattedMessage id = "pageDoesNotExist" values=
+              {{inputValueRef:`${pathname}`}}/>
+            </h1>
           </div>
           <div className="alert alert-info">
-            <p>{message}</p>
-            <p>Vérifiez l'orthographe de l'URL.</p>
-            <p>Si ce lien fonctionnait et ne fonctionne plus, vérifiez le <a href={changelogURL}>changelog</a>.</p>
+            <p> <FormattedMessage id = "checkChangelog" values=
+              {{changelogURLLink:
+                <a href = {changelogURL} target = "_blank">changelog</a>
+              }}/>
+            </p>
           </div>
-          <Link className="btn btn-default" to="/">Retour à l'accueil</Link>
+          <Link className="btn btn-default" to="/"><FormattedMessage id = "backToHP"/></Link>
           <hr></hr>
-          <h3>Explorez la base de paramètres et variables OpenFisca</h3>
+          <h3><FormattedMessage id = "explore"/></h3>
           <div>
             <form onSubmit={this.handleSubmit}>
               <div className="input-group input-group-lg" style={{margin: "2em 0"}}>
@@ -55,7 +60,7 @@ const NotFoundPage = React.createClass({
                   onChange={this.handleInputChange}
                 />
                 <div className="input-group-btn">
-                  <button className="btn btn-primary" type="submit" >Trouver</button>
+                  <button className="btn btn-primary" type="submit" ><FormattedMessage id = "find"/></button>
                 </div>
               </div>
             </form>

--- a/src/components/pages/not-found.jsx
+++ b/src/components/pages/not-found.jsx
@@ -12,7 +12,6 @@ const NotFoundPage = React.createClass({
   propTypes: {
     location: locationShape.isRequired,
     message: PropTypes.string,
-    countryPackageName: PropTypes.string
   },
 
   handleInputChange(event) {
@@ -29,7 +28,6 @@ const NotFoundPage = React.createClass({
 
   render() {
     const {pathname} = this.props.location
-    const countryPackageName = this.props.countryPackageName
     const changelogURL = `https://www.github.com/${config.gitHubProject}/blob/master/CHANGELOG.md`
     return (
       <DocumentTitle title={`Page non trouvée - Explorateur de la législation`}>

--- a/src/components/pages/not-found.jsx
+++ b/src/components/pages/not-found.jsx
@@ -1,17 +1,30 @@
-import {Link, locationShape} from "react-router"
+import { Link, locationShape, routerShape } from "react-router"
 import React, {PropTypes} from "react"
 import DocumentTitle from "react-document-title"
 
-import HomePage from "./home"
-
 const NotFoundPage = React.createClass({
+  contextTypes: {
+    router: routerShape.isRequired
+  },
+
   propTypes: {
     location: locationShape.isRequired,
     message: PropTypes.string,
-    countryPackageName: PropTypes.string,
-  handleSubmit(event) {
-    return <HomePage/>
+    countryPackageName: PropTypes.string
   },
+
+  handleInputChange(event) {
+    this.setState({inputValue: event.target.value})
+  },
+
+  handleSubmit(event) {
+    event.preventDefault()
+    this.context.router.push({
+      query: {q: this.state.inputValue},
+      hash: `#search-input`,
+    })
+  },
+
   render() {
     const {pathname} = this.props.location
     const message = this.props.message || `La page « ${pathname} » n'existe pas.`
@@ -21,39 +34,36 @@ const NotFoundPage = React.createClass({
       <DocumentTitle title={`Page non trouvée - Explorateur de la législation`}>
         <div>
           <div className="page-header">
-            <h1>Page non trouvée</h1>
             <h1>La page « {pathname} » n'existe pas.</h1>
           </div>
-          <div className="alert alert-danger">
-            {message}
           <div className="alert alert-info">
             <p>{message}</p>
-            <p>Vérifiez l'orthographe de l'URL. Si ce lien fonctionnait et ne fonctionne plus, vérifiez le <a href={changelogURL}>changelog</a>.</p>
+            <p>Vérifiez l'orthographe de l'URL.</p>
+            <p>Si ce lien fonctionnait et ne fonctionne plus, vérifiez le <a href={changelogURL}>changelog</a>.</p>
           </div>
           <Link className="btn btn-default" to="/">Retour à l'accueil</Link>
           <hr></hr>
           <h3>Explorez la base de paramètres et variables OpenFisca</h3>
           <div>
-          <form onSubmit={this.handleSubmit}>
-            <div className="input-group input-group-lg" style={{margin: "2em 0"}}>
-              <input
-                autoFocus={true}
-                className="form-control"
-                id="searchInputId"
-                placeholder="smic, salaire net…"
-                type="text"
-              />
-              <div className="input-group-btn">
-                <button className="btn btn-primary" href="http://www.openfisca.com">Trouver</button>
+            <form onSubmit={this.handleSubmit}>
+              <div className="input-group input-group-lg" style={{margin: "2em 0"}}>
+                <input
+                  className="form-control"
+                  id="searchInputId"
+                  placeholder="smic, salaire net…"
+                  type="text"
+                  onChange={this.handleInputChange}
+                />
+                <div className="input-group-btn">
+                  <button className="btn btn-primary" type="submit" >Trouver</button>
+                </div>
               </div>
-            </div>
-          </form>
-        </div>
+            </form>
+          </div>
         </div>
       </DocumentTitle>
     )
   },
 })
-
 
 export default NotFoundPage

--- a/src/components/pages/not-found.jsx
+++ b/src/components/pages/not-found.jsx
@@ -2,7 +2,9 @@ import { Link, locationShape, routerShape } from "react-router"
 import React, {PropTypes} from "react"
 import DocumentTitle from "react-document-title"
 import {FormattedMessage} from "react-intl"
+import SearchBarComponent from "./searchbar"
 import config from "../../config"
+
 
 const NotFoundPage = React.createClass({
   contextTypes: {
@@ -14,17 +16,6 @@ const NotFoundPage = React.createClass({
     message: PropTypes.string,
   },
 
-  handleInputChange(event) {
-    this.setState({inputValue: event.target.value})
-  },
-
-  handleSubmit(event) {
-    event.preventDefault()
-    this.context.router.push({
-      query: {q: this.state.inputValue},
-      hash: `#search-input`,
-    })
-  },
 
   render() {
     const {pathname} = this.props.location
@@ -48,22 +39,7 @@ const NotFoundPage = React.createClass({
           <Link className="btn btn-default" to="/"><FormattedMessage id = "backToHP"/></Link>
           <hr></hr>
           <h3><FormattedMessage id = "explore"/></h3>
-          <div>
-            <form onSubmit={this.handleSubmit}>
-              <div className="input-group input-group-lg" style={{margin: "2em 0"}}>
-                <input
-                  className="form-control"
-                  id="searchInputId"
-                  placeholder="smic, salaire net…"
-                  type="text"
-                  onChange={this.handleInputChange}
-                />
-                <div className="input-group-btn">
-                  <button className="btn btn-primary" type="submit" ><FormattedMessage id = "find"/></button>
-                </div>
-              </div>
-            </form>
-          </div>
+          <SearchBarComponent/>
         </div>
       </DocumentTitle>
     )

--- a/src/components/pages/not-found.jsx
+++ b/src/components/pages/not-found.jsx
@@ -16,7 +16,6 @@ const NotFoundPage = React.createClass({
     message: PropTypes.string,
   },
 
-
   render() {
     const {pathname} = this.props.location
     const changelogURL = `https://www.github.com/${config.gitHubProject}/blob/master/CHANGELOG.md`
@@ -45,5 +44,6 @@ const NotFoundPage = React.createClass({
     )
   },
 })
+
 
 export default NotFoundPage

--- a/src/components/pages/parameter-or-variable.jsx
+++ b/src/components/pages/parameter-or-variable.jsx
@@ -52,9 +52,9 @@ const ParameterOrVariablePage = React.createClass({
   handleNotFound(){
     const name = this.props.params.name
     return this.context.router.push({
-    query: {q: name, source: '404'},
-    hash: `#not-found`,
-    })
+      query: {q: name, is404: true},
+      hash: `#not-found`,
+      })
   },
 
   render() {

--- a/src/components/pages/parameter-or-variable.jsx
+++ b/src/components/pages/parameter-or-variable.jsx
@@ -1,9 +1,7 @@
 import React, { PropTypes } from "react"
-import { isNil } from "ramda"
 import { Link, locationShape, routerShape } from "react-router"
 
 import * as AppPropTypes from "../../app-prop-types"
-import NotFoundPage from "./not-found"
 import Parameter from "../parameter"
 import Variable from "../variable"
 import { searchInputId } from "./home"
@@ -42,6 +40,7 @@ const ParameterOrVariablePage = React.createClass({
       )
     } else {
         this.setState({waitingForResponse: false})
+        this.handleNotFound()
     }
   },
   componentWillReceiveProps(nextProps) {
@@ -50,11 +49,23 @@ const ParameterOrVariablePage = React.createClass({
   componentDidMount() {
     this.fetchPageContent(this.props.params.name)
   },
+  handleNotFound(){
+    const name = this.props.params.name
+    return this.context.router.push({
+    query: {q: name, source: '404'},
+    hash: `#not-found`,
+    })
+  },
+
   render() {
     const { searchQuery, searchResults } = this.context
-    const {countryPackageName, countryPackageVersion, location, parameters, params, variables} = this.props
-    const {name} = params
+    const {countryPackageName, countryPackageVersion, parameters, variables} = this.props
     const {parameter, variable} = this.state
+    const goBackLocation = {
+      pathname: "/",
+      query: {q: searchQuery},
+      hash: `#${searchInputId}`,
+    }
 
     if (this.state.waitingForResponse) {
       return (
@@ -62,19 +73,6 @@ const ParameterOrVariablePage = React.createClass({
       )
     }
 
-    if (isNil(parameter) && isNil(variable)) {
-      return (
-         this.context.router.push({
-          query: {q: name, source: '404'},
-          hash: `#not-found`,
-            })
-      )
-    }
-    const goBackLocation = {
-      pathname: "/",
-      query: {q: searchQuery},
-      hash: `#${searchInputId}`,
-    }
     return (
       <div>
         <Link className="btn btn-default" to={goBackLocation}>

--- a/src/components/pages/parameter-or-variable.jsx
+++ b/src/components/pages/parameter-or-variable.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react"
 import { isNil } from "ramda"
-import { Link, locationShape } from "react-router"
+import { Link, locationShape, routerShape } from "react-router"
 
 import * as AppPropTypes from "../../app-prop-types"
 import NotFoundPage from "./not-found"
@@ -12,6 +12,7 @@ import { fetchParameter, fetchVariable } from "../../webservices"
 
 const ParameterOrVariablePage = React.createClass({
   contextTypes: {
+    router: routerShape.isRequired,
     searchQuery: PropTypes.string.isRequired,
     searchResults: PropTypes.array.isRequired,
   },
@@ -63,11 +64,10 @@ const ParameterOrVariablePage = React.createClass({
 
     if (isNil(parameter) && isNil(variable)) {
       return (
-        <NotFoundPage
-          location={location}
-          message={`« ${name} » n'est ni un paramètre ni une variable d'OpenFisca.`}
-          countryPackageName={countryPackageName}
-        />
+         this.context.router.push({
+          query: {q: name, source: '404'},
+          hash: `#not-found`,
+            })
       )
     }
     const goBackLocation = {

--- a/src/components/pages/parameter-or-variable.jsx
+++ b/src/components/pages/parameter-or-variable.jsx
@@ -53,7 +53,7 @@ const ParameterOrVariablePage = React.createClass({
     const name = this.props.params.name
     return this.context.router.push({
       query: {q: name, is404: true},
-      hash: `#not-found`,
+      hash: '#not-found',
       })
   },
 

--- a/src/components/pages/parameter-or-variable.jsx
+++ b/src/components/pages/parameter-or-variable.jsx
@@ -66,6 +66,7 @@ const ParameterOrVariablePage = React.createClass({
         <NotFoundPage
           location={location}
           message={`« ${name} » n'est ni un paramètre ni une variable d'OpenFisca.`}
+          countryPackageName={countryPackageName}
         />
       )
     }

--- a/src/components/pages/searchbar.jsx
+++ b/src/components/pages/searchbar.jsx
@@ -1,4 +1,4 @@
-import { Link, routerShape } from "react-router"
+import { routerShape } from "react-router"
 import React, {PropTypes} from "react"
 import {FormattedMessage} from "react-intl"
 

--- a/src/components/pages/searchbar.jsx
+++ b/src/components/pages/searchbar.jsx
@@ -55,4 +55,5 @@ const SearchBarComponent = React.createClass({
   },
 })
 
+
 export default SearchBarComponent

--- a/src/components/pages/searchbar.jsx
+++ b/src/components/pages/searchbar.jsx
@@ -1,5 +1,5 @@
 import { routerShape } from "react-router"
-import React, {PropTypes} from "react"
+import React from "react"
 import {FormattedMessage} from "react-intl"
 
 import { searchInputId } from "./home"
@@ -7,11 +7,10 @@ import { searchInputId } from "./home"
 const SearchBarComponent = React.createClass({
   contextTypes: {
     router: routerShape.isRequired,
-    searchQuery: PropTypes.string.isRequired,
   },
 
   getInitialState() {
-    return {inputValue: this.context.searchQuery}
+    return {inputValue: this.props.initialValue}
   },
 
   handleInputChange(event) {
@@ -25,6 +24,10 @@ const SearchBarComponent = React.createClass({
       query: {q: this.state.inputValue},
       hash: `#search-input`,
     })
+  },
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({inputValue: nextProps.initialValue})
   },
 
   render() {

--- a/src/components/pages/searchbar.jsx
+++ b/src/components/pages/searchbar.jsx
@@ -1,0 +1,55 @@
+import { Link, routerShape } from "react-router"
+import React, {PropTypes} from "react"
+import {FormattedMessage} from "react-intl"
+
+import { searchInputId } from "./home"
+
+const SearchBarComponent = React.createClass({
+  contextTypes: {
+    router: routerShape.isRequired,
+    searchQuery: PropTypes.string.isRequired,
+  },
+
+  getInitialState() {
+    return {inputValue: this.context.searchQuery}
+  },
+
+  handleInputChange(event) {
+    this.setState({inputValue: event.target.value})
+    this.searchInput.scrollIntoView()
+  },
+
+  handleSubmit(event) {
+    event.preventDefault()
+    this.context.router.push({
+      query: {q: this.state.inputValue},
+      hash: `#search-input`,
+    })
+  },
+
+  render() {
+    const inputValue = this.state.inputValue
+    return (
+      <div>
+        <form onSubmit={this.handleSubmit}>
+          <div className="input-group input-group-lg" style={{margin: "2em 0"}}>
+            <input
+              className="form-control"
+              id={searchInputId}
+              placeholder="smic, salaire net…"
+              type="text"
+              onChange={this.handleInputChange}
+              value = {inputValue}
+              ref={element => this.searchInput = element}
+            />
+            <div className="input-group-btn">
+              <button className="btn btn-primary" type="submit" ><FormattedMessage id = "find"/></button>
+            </div>
+          </div>
+        </form>
+      </div>
+    )
+  },
+})
+
+export default SearchBarComponent


### PR DESCRIPTION
Connected to #83

This PR should add the following behavior : 
the user types : legislation.openfisca.fr/fakename
--> they are redirected on the homepage, with an info message and a search for 'fakename' already processed

the user types  legislation.openfisca.fr/fakename/faky
--> they are directed to a dedicated 404 page with a seach bar that has not been populated. On submit, this search bar directs them to the homepage with the search they entered processed.

Finally, I tried to clarify the integration test part of the read me.

-----

EDIT by @fpagnoux: Add reference issue