### PR TITLE
Use HTTPS for the API

### DIFF
--- a/config/production.france.js
+++ b/config/production.france.js
@@ -4,7 +4,7 @@
 import winston from "winston"
 
 
-const  apiBaseUrl = process.env.API_URL || `http://fr.openfisca.org/api/v2`,
+const  apiBaseUrl = process.env.API_URL || `https://fr.openfisca.org/api/v2`,
   gitHubProject = "openfisca/openfisca-france",
   gitWebpageUrl = "https://github.com/openfisca/legislation-explorer",
   piwikConfig = {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently --kill-others 'npm run dev:app-server' 'npm run dev:webpack-dev-server'",
     "dev:app-server": "NODE_ENV=development PORT=2030 node index.js",
     "dev:webpack-dev-server": "WEBPACK_PORT=2031 babel-node src/server/webpack-dev-server.js",
-    "dev:prod-api": "API_URL=http://fr.openfisca.org/api/v2 npm run dev",
+    "dev:prod-api": "API_URL=https://fr.openfisca.org/api/v2 npm run dev",
     "lint": "eslint --ext .js,.jsx .",
     "start": "NODE_ENV=production PORT=2030 node index.js",
     "test:unit": "mocha --compilers js:babel-core/register tests/unit/**/*.js",


### PR DESCRIPTION
The API calls must be done in HTTPS if we want to serve the legislation explorer in HTTPS.

Connected to openfisca/openfisca-core#572