### PR TITLE
Remove invisible spaces from parameters' titles

### DIFF
--- a/src/components/parameter.jsx
+++ b/src/components/parameter.jsx
@@ -19,9 +19,8 @@ const Parameter = React.createClass({
     const {parameter} = this.props
     const description = parameter.description || "Aucune description"
     const isScale = (! parameter.values)
-    //Add soft hyphens to break long parameter id before dots
-    //const multilineId = parameter.id.replace(/\./g, '\u200b.')
-    const multilineId = '<span>' + parameter.id.replace(/\./g, '</span><span>.') + '</span>'
+    //Add word break opportunities before dots for long parameter id
+    const multilineId = parameter.id.replace(/\./g, '<wbr>.')
 
     return (
       <DocumentTitle title={`${parameter.id} - Explorateur de la législation`}>

--- a/src/components/parameter.jsx
+++ b/src/components/parameter.jsx
@@ -20,13 +20,14 @@ const Parameter = React.createClass({
     const description = parameter.description || "Aucune description"
     const isScale = (! parameter.values)
     //Add soft hyphens to break long parameter id before dots
-    const multilineId = parameter.id.replace(/\./g, '\u200b.')
+    //const multilineId = parameter.id.replace(/\./g, '\u200b.')
+    const multilineId = '<span>' + parameter.id.replace(/\./g, '</span><span>.') + '</span>'
 
     return (
       <DocumentTitle title={`${parameter.id} - Explorateur de la législation`}>
         <div>
           <header className="page-header">
-            <h1><code>{multilineId}</code></h1>
+            <h1><code dangerouslySetInnerHTML={{__html: multilineId}}></code></h1>
             <p className="description">{description}</p>
           </header>
           <div className="row">


### PR DESCRIPTION
Fixes #125 

On parameter pages, update titles to:
* remove invisible spaces before dots
* break long titles on multiple lines
* keep an easy copy/paste of the parameter id