### PR TITLE
Fix integration tests

### DIFF
--- a/tests/integration/VariableFixture.js
+++ b/tests/integration/VariableFixture.js
@@ -1,2 +1,2 @@
 aahDependencyTitle = "aah_base"
-enumVariableFirstValue = /Marié/
+enumVariableFirstValue = "0"


### PR DESCRIPTION
Integration test are failing because one test is using enums but they're not yet available.