### PR TITLE
Use API v20 for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently --kill-others 'npm run dev:app-server' 'npm run dev:webpack-dev-server'",
     "dev:app-server": "NODE_ENV=development PORT=2030 node index.js",
     "dev:webpack-dev-server": "WEBPACK_PORT=2031 babel-node src/server/webpack-dev-server.js",
-    "dev:prod-api": "API_URL=https://fr.openfisca.org/api/v18 npm run dev",
+    "dev:prod-api": "API_URL=https://fr.openfisca.org/api/v20 npm run dev",
     "lint": "eslint --ext .js,.jsx .",
     "start": "NODE_ENV=production PORT=2030 node index.js",
     "test:unit": "mocha --compilers js:babel-core/register tests/unit/**/*.js",


### PR DESCRIPTION
Update reference from v18 to v20 to be used as the API version for development.