### PR TITLE
Fix logo

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -60,7 +60,7 @@ const App = React.createClass({
                 <div className="col-md-3">
                   <img
                     alt="OpenFisca"
-                    src={url.resolve(config.websiteUrl, "/hotlinks/logo-openfisca.svg")}
+                    src={"http://openfisca.org/img/logo-openfisca.svg"}
                     style={{maxWidth: "12em"}}
                   />
                   <p id="country-package-info">

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -1,4 +1,3 @@
-import url from "url"
 
 import DocumentTitle from "react-document-title"
 import React, {PropTypes} from "react"


### PR DESCRIPTION
After the change of website, the old logo link broke.

This links the logo on the legislation explorer to the openfisca.org website