### PR TITLE
Add option to set a basename

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Type the following commands from the project root directory:
 
     Open http://localhost:2030/
 
-- Production server:
+- Production server, served on root directory (e.g. legislation.openfisca.fr):
 
     ```sh
     npm install
@@ -36,6 +36,20 @@ Type the following commands from the project root directory:
     ```
 
     Open http://localhost:2030/
+
+- Production server, served on sub-directory (e.g. fr.openfisca.org/legislation):
+
+    ```sh
+    npm install
+    npm run clean
+    BASENAME=/legislation npm run build
+    BASENAME=/legislation NODE_ENV=production PORT=2030 node index.js
+    ```
+
+    Open http://your.reverse.proxy/legislation
+
+    To work with nginx as a reverse proxy, you need to set up a [ngx_http_upstream_module](http://nginx.org/en/docs/http/ngx_http_upstream_module.html).
+    See the [fr.openfisca.org nginx configuration](https://github.com/openfisca/openfisca-ops/blob/master/fr.openfisca.org/fr.openfisca.org.conf) to learn more.
 
 ## Auto-update the legislation
 

--- a/deploy_prod.sh
+++ b/deploy_prod.sh
@@ -6,7 +6,7 @@ git branch
 
 git pull
 npm install
-npm run build
+BASENAME=/legislation npm run build
 
 echo "Restarting legislation-explorer service..."
 sudo systemctl restart legislation-explorer.service

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "classnames": "^2.2.5",
     "diacritics": "^1.3.0",
     "express": "^4.12.4",
+    "history": "^2.1.2",
     "intl": "^1.2.4",
     "intl-locales-supported": "^1.0.0",
     "isomorphic-fetch": "^2.2.1",

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -1,7 +1,8 @@
 import PiwikReactRouter from "piwik-react-router"
 import React from "react"
 import {render} from "react-dom"
-import {Router, browserHistory} from "react-router"
+import {createHistory} from "history"
+import {Router, useRouterHistory} from "react-router"
 
 import {addLocaleData, IntlProvider} from "react-intl"
 
@@ -30,9 +31,12 @@ function hashLinkScroll() {
 export function renderApp() {
   const appMountNode = document.getElementById("app-mount-node")
   const initialState = window.__INITIAL_STATE__
-  const history = config.piwikConfig
-    ? PiwikReactRouter(config.piwikConfig).connectToHistory(browserHistory)
-    : browserHistory
+  const basename = process.env.BASENAME || "/"
+  let history = useRouterHistory(createHistory)({basename: basename})
+
+  if (config.piwikConfig) {
+    history = PiwikReactRouter(config.piwikConfig).connectToHistory(history)
+  }
 
   addLocaleData(require(`react-intl/locale-data/${initialState.locale}`))
 

--- a/src/components/pages/parameter-or-variable.jsx
+++ b/src/components/pages/parameter-or-variable.jsx
@@ -52,8 +52,9 @@ const ParameterOrVariablePage = React.createClass({
   handleNotFound() {
     const name = this.props.params.name
     return this.context.router.push({
+      pathname: "/",
       query: {q: name, is404: true},
-      hash: '#not-found',
+      hash: "#not-found",
       })
   },
 

--- a/src/components/pages/searchbar.jsx
+++ b/src/components/pages/searchbar.jsx
@@ -21,8 +21,9 @@ const SearchBarComponent = React.createClass({
   handleSubmit(event) {
     event.preventDefault()
     this.context.router.push({
+      pathname: "/",
       query: {q: this.state.inputValue},
-      hash: `#search-input`,
+      hash: "#search-input",
     })
   },
 

--- a/src/server/render.jsx
+++ b/src/server/render.jsx
@@ -54,11 +54,20 @@ function renderHtmlDocument(renderProps, state) {
     </IntlProvider>
   )
   const webpackAssets = loadWebpackAssets()
+  const basename = process.env.BASENAME || ""
+
   // Add external CSS copied to the public directory by CopyWebpackPlugin in webpack config.
   const bootstrapCss = process.env.NODE_ENV === "production"
-    ? "/bootstrap/css/bootstrap.min.css"
-    : "/bootstrap/css/bootstrap.css"
-  let externalCss = [bootstrapCss, '/swagger-ui.css', '/github-gist.css', '/style.css']
+    ? `${basename}/bootstrap/css/bootstrap.min.css`
+    : `${basename}/bootstrap/css/bootstrap.css`
+
+  let externalCss = [
+    bootstrapCss,
+    `${basename}/swagger-ui.css`,
+    `${basename}/github-gist.css`,
+    `${basename}/style.css`
+  ]
+
   if (process.env.NODE_ENV === "development") {
     externalCss = externalCss.map(
       value => "http://localhost:2031" + value // FIXME: the port should not be hard-coded.

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -8,7 +8,7 @@ import writeAssets from "./src/server/write-assets"
 
 
 const assetsPath = path.join(__dirname, "public")
-
+const basename = process.env.BASENAME || ""
 
 module.exports = {
   // devtool: "eval", // Transformed code
@@ -19,7 +19,7 @@ module.exports = {
   output: {
     path: assetsPath,
     filename: "[name]-[hash].js",
-    publicPath: "/",
+    publicPath: `${basename}/`,
   },
   target: 'web',
   // yaml-js has a reference to `fs`, this is a workaround
@@ -49,6 +49,7 @@ module.exports = {
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify("production"), // clean up some react stuff
+        BASENAME: JSON.stringify(basename),
         COUNTRY_PRODUCTION_CONFIG: JSON.stringify(process.env.COUNTRY_PRODUCTION_CONFIG || "france")
       },
     }),


### PR DESCRIPTION
Connected to openfisca/openfisca-ops#13

To add with a basename, example fr.openfisca.org/legislation:

```
BASEPATH=/legislation npm run build
BASEPATH=/legislation node index.js
```

~Test with https://fr.openfisca.org/tmp~

Thanks to @Anna-Livia and @sandcha 