### PR TITLE
Use international website in description

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -10,7 +10,7 @@ const HOST = process.env.HOST || "localhost",
   gitWebpageUrl = "https://github.com/openfisca/legislation-explorer",
   piwikConfig = null,
   useCommitReferenceFromApi = true,
-  websiteUrl = "https://www.openfisca.fr/",
+  websiteUrl = "http://openfisca.org/",
   winstonConfig = {
     transports: [
       new (winston.transports.Console)({timestamp: true}),


### PR DESCRIPTION
We want “learn more” here to link to openfisca.org and let the target language be set dynamically rather than hardcoding French.

![screen shot 2018-05-09 at 15 21 54](https://user-images.githubusercontent.com/222463/39794106-bb2ff586-539c-11e8-9223-962dfd19efdc.png)
