### PR TITLE
Increase discoverability of loading indicator

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -49,6 +49,24 @@ td.list-entry{
   font-weight: bold;
 }
 
+.loading {
+  font-size: 200%;
+  text-align: center;
+}
+
+.loading .glyphicon-refresh {
+  display: block;
+  margin-bottom: .5em;
+
+  -webkit-animation: spin 4s linear infinite;
+  -moz-animation: spin 4s linear infinite;
+  animation: spin 4s linear infinite;
+}
+
+@-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
+@-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
+@keyframes spin { 100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); } }
+
 footer {
   margin-top: 10em;
 }

--- a/src/components/pages/parameter-or-variable.jsx
+++ b/src/components/pages/parameter-or-variable.jsx
@@ -72,7 +72,10 @@ const ParameterOrVariablePage = React.createClass({
 
     if (this.state.waitingForResponse) {
       return (
-        <FormattedMessage id="loading"/>
+        <div className="loading">
+          <span className="glyphicon glyphicon-refresh"></span>
+          <FormattedMessage id="loading"/>
+        </div>
       )
     }
 


### PR DESCRIPTION
The “loading content” text is hard to spot, making it not obvious when values are loading.

This changeset enlarges and centres the text, and adds a large spinning icon.


### Before

![screen shot 2018-05-21 at 18 42 49](https://user-images.githubusercontent.com/222463/40293850-e1e39b40-5d26-11e8-93d5-083b703e2e36.png)


### After

![screen shot 2018-05-21 at 18 42 31](https://user-images.githubusercontent.com/222463/40293858-e4574304-5d26-11e8-8628-f55534e4bcdd.png)

- - - -

Depends on #149.