### PR TITLE
Unify ended parameter with standard date changes

### DIFF
--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -13,7 +13,7 @@
   "elementNotFound": "Element does not exist",
   "noResultsFor": "No element in the current model matches “{input}”.",
 
-  "parameterNotInLegislationSince": "The legislation defining this parameter is not in effect from {startDate}",
+  "parameterNotInLegislation": "The legislation defining this parameter is not in effect",
   "fromDate": "From {startDate}",
   "fromToDate": "From {startDate} to {stopDate}",
 

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -13,7 +13,7 @@
   "elementNotFound": "Élément inexistant",
   "noResultsFor": "Aucun élément du modèle actuel ne correspond à « {input} ».",
 
-  "parameterNotInLegislationSince": "Ce paramètre ne figure plus dans la législation depuis le {startDate}",
+  "parameterNotInLegislation": "La législation définissant ce paramètre n’est plus effective",
   "fromDate": "À partir du {startDate}",
   "fromToDate": "Du {startDate} au {stopDate}",
 

--- a/src/components/parameter.jsx
+++ b/src/components/parameter.jsx
@@ -49,15 +49,20 @@ const Parameter = React.createClass({
   renderStartStopValue(parameter, startDate, stopDate, value, index) {
     return (
       <tr key={index}>
-        <td colSpan={value ? 1 : 2}>
-          <FormattedMessage id={value ? (stopDate ? 'fromToDate' : 'fromDate') : 'parameterNotInLegislationSince'}
+        <td>
+          <FormattedMessage id={stopDate ? 'fromToDate' : 'fromDate'}
             values={{
               startDate: <FormattedDate value={startDate} year="numeric" month="2-digit" day="2-digit" />,
               stopDate: stopDate && <FormattedDate value={stopDate} year="numeric" month="2-digit" day="2-digit" />
             }}
           />
         </td>
-        { value && <td><samp><FormattedNumber value={value}/></samp></td> }
+        <td>
+          { value
+            ? <samp><FormattedNumber value={value}/></samp>
+            : <em><FormattedMessage id="parameterNotInLegislation"/></em>
+          }
+        </td>
       </tr>
     )
   },


### PR DESCRIPTION
When a parameter ends, it is represented as a full-width sentence that prevents easy scanning of the date and brings unnecessary complexity in the code.

This changeset unifies the presentation and presents the end as another type of value.

### Before

![screen shot 2018-05-19 at 20 47 32](https://user-images.githubusercontent.com/222463/40293947-607d38ee-5d27-11e8-8b52-ea8bf12d5c04.png)

### After

![screen shot 2018-05-19 at 21 04 23](https://user-images.githubusercontent.com/222463/40293953-67696ac4-5d27-11e8-88ea-1e7ab2af6e16.png)

- - - -

Depends on #149.