### PR TITLE
Specify the minimum supported version of npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
     "webpack-dev-server": "^1.9.0",
     "webpack-error-notification": "^0.1.4"
   },
+  "engines": {
+    "npm": ">=5.0.0"
+  },
   "private": true
 }


### PR DESCRIPTION
Based on #145 (`package-lock.json`), I think it is important to specify the minimum version of `npm` required in the `package.json` file (v5).