### PR TITLE
Decrease and standardise proptypes API surface

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -5,7 +5,7 @@ import {locationShape, Link} from "react-router"
 import {FormattedMessage, injectIntl, intlShape} from "react-intl"
 import ExternalLink from "./external-link"
 
-import * as AppPropTypes from "../app-prop-types"
+import { parameterShape, variableShape } from "../openfisca-proptypes"
 import config from "../config"
 import {findParametersAndVariables} from "../search"
 
@@ -20,8 +20,8 @@ const App = React.createClass({
     countryPackageName: PropTypes.string.isRequired,
     countryPackageVersion: PropTypes.string.isRequired,
     location: locationShape.isRequired,
-    parameters: PropTypes.objectOf(AppPropTypes.parameter).isRequired,
-    variables: PropTypes.objectOf(AppPropTypes.variable).isRequired,
+    parameters: PropTypes.objectOf(parameterShape).isRequired,
+    variables: PropTypes.objectOf(variableShape).isRequired,
   },
   getChildContext() {
     const {parameters, variables} = this.props

--- a/src/components/formula.jsx
+++ b/src/components/formula.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react"
-import * as AppPropTypes from "../app-prop-types"
+import { parameterShape, variableShape } from "../openfisca-proptypes"
 import { Link } from "react-router"
 import { FormattedMessage, FormattedDate } from "react-intl"
 import { flatten, pipe, map, is } from "ramda"
@@ -12,8 +12,8 @@ const Formula = React.createClass({
     stopDate: PropTypes.string,
     content: PropTypes.string.isRequired,
     source: PropTypes.string.isRequired,
-    parameters: PropTypes.objectOf(AppPropTypes.parameter).isRequired,
-    variables: PropTypes.objectOf(AppPropTypes.variable).isRequired,
+    parameters: PropTypes.objectOf(parameterShape).isRequired,
+    variables: PropTypes.objectOf(variableShape).isRequired,
   },
 
   render() {

--- a/src/components/pages/home.jsx
+++ b/src/components/pages/home.jsx
@@ -4,7 +4,7 @@ import {Link, locationShape, routerShape} from "react-router"
 import {FormattedMessage, injectIntl, intlShape} from "react-intl"
 import DocumentTitle from "react-document-title"
 
-import * as AppPropTypes from "../../app-prop-types"
+import { parameterShape, variableShape } from "../../openfisca-proptypes"
 import List from "../list"
 import config from "../../config"
 import SearchBarComponent from "./searchbar"
@@ -22,8 +22,8 @@ const HomePage = React.createClass({
     countryPackageVersion: PropTypes.string.isRequired,
     intl: intlShape,
     location: locationShape.isRequired,
-    parameters: PropTypes.objectOf(AppPropTypes.parameter).isRequired,
-    variables: PropTypes.objectOf(AppPropTypes.variable).isRequired,
+    parameters: PropTypes.objectOf(parameterShape).isRequired,
+    variables: PropTypes.objectOf(variableShape).isRequired,
   },
   componentDidMount() {
     this._isMounted = true

--- a/src/components/pages/parameter-or-variable.jsx
+++ b/src/components/pages/parameter-or-variable.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react"
 import { Link, locationShape, routerShape } from "react-router"
 import { FormattedMessage } from "react-intl"
 
-import * as AppPropTypes from "../../app-prop-types"
+import { parameterShape, variableShape } from "../../openfisca-proptypes"
 import Parameter from "../parameter"
 import Variable from "../variable"
 import { searchInputId } from "./home"
@@ -20,8 +20,8 @@ const ParameterOrVariablePage = React.createClass({
     countryPackageVersion: PropTypes.string.isRequired,
     location: locationShape.isRequired,
     params: PropTypes.shape({ name: PropTypes.string.isRequired }).isRequired, // URL params
-    parameters: PropTypes.objectOf(AppPropTypes.parameter).isRequired,
-    variables: PropTypes.objectOf(AppPropTypes.variable).isRequired,
+    parameters: PropTypes.objectOf(parameterShape).isRequired,
+    variables: PropTypes.objectOf(variableShape).isRequired,
   },
   getInitialState() {
     return {variable: null, parameter: null, waitingForResponse: true}

--- a/src/components/parameter.jsx
+++ b/src/components/parameter.jsx
@@ -3,7 +3,7 @@ import { FormattedMessage, FormattedDate, FormattedNumber, injectIntl, intlShape
 import React, {PropTypes} from "react"
 
 import config from "../config"
-import * as AppPropTypes from "../app-prop-types"
+import { parameterShape } from "../openfisca-proptypes"
 import ExternalLink from "./external-link"
 import Scale from "./scale"
 import getDayBefore from "../periods"
@@ -13,7 +13,7 @@ const Parameter = React.createClass({
     countryPackageName: PropTypes.string.isRequired,
     countryPackageVersion: PropTypes.string.isRequired,
     intl: intlShape.isRequired,
-    parameter: AppPropTypes.parameter.isRequired,
+    parameter: parameterShape.isRequired,
   },
   render() {
     const {parameter} = this.props

--- a/src/components/scale.jsx
+++ b/src/components/scale.jsx
@@ -2,12 +2,12 @@ import classNames from "classnames"
 import React from "react"
 import { FormattedMessage, FormattedDate, FormattedNumber } from 'react-intl';
 
-import * as AppPropTypes from "../app-prop-types"
+import { parameterShape } from "../openfisca-proptypes"
 
 
 const Scale = React.createClass({
   propTypes: {
-    parameter: AppPropTypes.parameter.isRequired,
+    parameter: parameterShape.isRequired,
   },
   render() {
     const {brackets} = this.props.parameter

--- a/src/components/variable.jsx
+++ b/src/components/variable.jsx
@@ -4,7 +4,7 @@ import React, { PropTypes } from "react"
 import { keys } from "ramda"
 
 import config from "../config"
-import * as AppPropTypes from "../app-prop-types"
+import { parameterShape, variableShape } from "../openfisca-proptypes"
 import ExternalLink from "./external-link"
 import Formula from "./formula"
 import getDayBefore from "../periods"
@@ -14,9 +14,9 @@ const Variable = React.createClass({
     countryPackageName: PropTypes.string.isRequired,
     countryPackageVersion: PropTypes.string.isRequired,
     intl: intlShape.isRequired,
-    parameters: PropTypes.objectOf(AppPropTypes.parameter).isRequired,
-    variable: AppPropTypes.variable.isRequired,
-    variables: PropTypes.objectOf(AppPropTypes.variable).isRequired,
+    parameters: PropTypes.objectOf(parameterShape).isRequired,
+    variable: variableShape.isRequired,
+    variables: PropTypes.objectOf(variableShape).isRequired,
   },
   getTodayInstant() {
     return new Date().toJSON().slice(0, 10)

--- a/src/openfisca-proptypes.js
+++ b/src/openfisca-proptypes.js
@@ -1,25 +1,21 @@
-import {PropTypes} from "react"
+import { PropTypes } from "react"
 
 
-// Level 0 PropTypes
-
-export const value = PropTypes.oneOfType([
+const valuesShape = PropTypes.objectOf(PropTypes.oneOfType([
   PropTypes.bool,
   PropTypes.number,
   PropTypes.string,
-])
+]))
 
-export const values = PropTypes.objectOf(value)
-
-export const parameter = PropTypes.shape({
+export const parameterShape = PropTypes.shape({
   id: PropTypes.string,
   description: PropTypes.string,
   normalizedDescription: PropTypes.string,
-  brackets: PropTypes.objectOf(values),
-  values,
+  values: valuesShape,
+  brackets: PropTypes.objectOf(valuesShape),
 })
 
-export const variable = PropTypes.shape({
+export const variableShape = PropTypes.shape({
   id: PropTypes.string,
   description: PropTypes.string,
   definitionPeriod: PropTypes.string,


### PR DESCRIPTION
- Do not export unused shapes
- Do not `import *`
- Use standard React `shape` suffix for proptypes