### PR TITLE
Don't use a buggy version of swagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-intl": "^2.1.2",
     "react-router": "^3.2.1",
     "serve-favicon": "^2.3.0",
-    "swagger-ui": "^3.17.3",
+    "swagger-ui": "3.17.3",
     "webpack": "^1.9.11"
   },
   "devDependencies": {


### PR DESCRIPTION
On several environment (production server, my machine), `swagger-ui@3.18.0` is causing trouble:

```
warning "swagger-ui > webpack-dev-server@2.11.2" has incorrect peer dependency "webpack@^2.2.0 || ^3.0.0".
(...)
[0] TypeError: _dompurify2.default.addHook is not a function
[0]     at Object.<anonymous> (/Users/florianpagnoux/Dev/openfisca/legislation-explorer/node_modules/swagger-ui/dist/webpack:/src/core/components/providers/markdown.jsx:7:11)
[0]     at __webpack_require__ (/Users/florianpagnoux/Dev/openfisca/legislation-explorer/node_modules/swagger-ui/dist/webpack:/webpack/bootstrap e373ce07a3ac6fb7d981:19:1)
(...) 
```

This fixes the dependencies to a version that is known to work