### PR TITLE
Reduce Bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "react-router": "^3.2.1",
     "serve-favicon": "^2.3.0",
     "swagger-ui": "~3.17.3",
-    "webpack": "^4.16.5"
+    "webpack": "^4.16.5",
+    "webpack-cli": "^3.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.6",
@@ -65,7 +66,6 @@
     "react-transform-hmr": "^1.0.4",
     "should": "^13.2.3",
     "watai": "^0.7.0",
-    "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.5",
     "webpack-error-notification": "^0.1.8"
   },

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -6,12 +6,8 @@ import MatomoReactRouter from 'piwik-react-router'
 import React from 'react'
 import { render } from 'react-dom'
 import { addLocaleData, IntlProvider } from 'react-intl'
-import en from 'react-intl/locale-data/de'
-import fr from 'react-intl/locale-data/fr'
 import { Router, useRouterHistory } from 'react-router'
 require('babel-polyfill')
-
-const localeData = { en, fr }
 
 
 // Adapted from: https://github.com/ReactTraining/react-router/issues/394#issuecomment-230116115
@@ -38,7 +34,7 @@ export function renderApp() {
   if (config.matomo)
     history = MatomoReactRouter(config.matomo).connectToHistory(history)
 
-  addLocaleData(localeData[initialState.locale])
+  addLocaleData(require(`react-intl/locale-data/${initialState.locale}`))
 
   render(
     <IntlProvider locale={initialState.locale} key={initialState.locale} messages={initialState.messages[initialState.locale]}>

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -6,8 +6,12 @@ import MatomoReactRouter from 'piwik-react-router'
 import React from 'react'
 import { render } from 'react-dom'
 import { addLocaleData, IntlProvider } from 'react-intl'
+import en from 'react-intl/locale-data/de'
+import fr from 'react-intl/locale-data/fr'
 import { Router, useRouterHistory } from 'react-router'
 require('babel-polyfill')
+
+const localeData = { en, fr }
 
 
 // Adapted from: https://github.com/ReactTraining/react-router/issues/394#issuecomment-230116115
@@ -34,7 +38,7 @@ export function renderApp() {
   if (config.matomo)
     history = MatomoReactRouter(config.matomo).connectToHistory(history)
 
-  addLocaleData(require(`react-intl/locale-data/${initialState.locale}`))
+  addLocaleData(localeData[initialState.locale])
 
   render(
     <IntlProvider locale={initialState.locale} key={initialState.locale} messages={initialState.messages[initialState.locale]}>

--- a/src/components/formula.jsx
+++ b/src/components/formula.jsx
@@ -4,7 +4,7 @@ import { parameterShape, variableShape } from '../openfisca-proptypes'
 import { Link } from 'react-router'
 import { FormattedMessage, FormattedDate } from 'react-intl'
 import { flatten, pipe, map, is } from 'ramda'
-import Highlight from 'react-highlight'
+import Highlight from 'react-highlight/lib/optimized'
 
 class Formula extends React.Component {
 
@@ -32,7 +32,7 @@ class Formula extends React.Component {
             />
           </h3>
         }
-        <Highlight className="python">{this.renderLinkedFormula(content)}</Highlight>
+        <Highlight languages={['python']} className="python">{this.renderLinkedFormula(content)}</Highlight>
         <p>
           <a href={source} rel="noopener" target="_blank"><FormattedMessage id="editThisFormula"/></a>
         </p>

--- a/src/server/lang.js
+++ b/src/server/lang.js
@@ -1,32 +1,27 @@
 import config from '../config'
 
 import acceptLanguage from 'accept-language'
+import {fromPairs} from 'ramda'
 
 import path from 'path'
-import {readdir} from 'fs'
+import {readdirSync} from 'fs'
 
 
 const DEFAULT_LANGUAGE = 'en'
 
 
 export function loadTranslations(langDir) {
-  var messages = {}
-  readdir(langDir, (err, files) => {
-    if (err) {
-      throw new Error("Unable to load translation files from '" + langDir + "' directory. See following error for more information: " + err)
-    }
-
-    files.forEach(file => {
-      messages[path.basename(file, '.json')] = require(path.resolve(langDir, file))
+  return fromPairs(
+    readdirSync(langDir).map(file => {
+      const lang = path.basename(file, '.json')
+      const messages = Object.assign(
+        {},
+        require(path.resolve(langDir, file)),
+        config.ui[lang]  // load all config-provided locale strings
+      )
+      return [lang, messages]
     })
-
-    // load all config-provided locale strings
-    Object.keys(messages).forEach(lang => {
-      Object.assign(messages[lang], config.ui[lang])
-    })
-  })
-
-  return messages
+  )
 }
 
 

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -69,6 +69,12 @@ module.exports = {
       new RegExp('^./(python)$')
     ),
 
+    // Only load locale for Fr and En
+    new webpack.ContextReplacementPlugin(
+      /react-intl\/locale-data$/,
+      new RegExp('^./(fr|en)$')
+    ),
+
     function() { this.plugin('done', writeAssets(path.resolve(__dirname, 'webpack-assets.json')).bind(this)) },
   ],
 }

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -63,6 +63,12 @@ module.exports = {
       {from: 'node_modules/swagger-ui/dist/swagger-ui.css', to: '.'},
     ]),
 
+    // Only load syntax highlighting for Python
+    new webpack.ContextReplacementPlugin(
+      /highlight\.js\/lib\/languages$/,
+      new RegExp('^./(python)$')
+    ),
+
     function() { this.plugin('done', writeAssets(path.resolve(__dirname, 'webpack-assets.json')).bind(this)) },
   ],
 }

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -71,7 +71,7 @@ module.exports = {
       new RegExp('^./(python)$')
     ),
 
-    // Only load locale for Fr and En
+    // Only load locale for supported languages
     new webpack.ContextReplacementPlugin(
       /react-intl\/locale-data$/,
       new RegExp(`^./(${supportedLanguages.join('|')})$`)

--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -5,9 +5,11 @@ import webpack from 'webpack'
 
 import config from './src/config'
 import writeAssets from './src/server/write-assets'
+import { loadTranslations } from './src/server/lang'
 
 
 const assetsPath = path.join(__dirname, 'public')
+const supportedLanguages = Object.keys(loadTranslations(path.join(__dirname, './src/assets/lang/')))
 
 module.exports = {
   // devtool: "eval", // Transformed code
@@ -72,7 +74,7 @@ module.exports = {
     // Only load locale for Fr and En
     new webpack.ContextReplacementPlugin(
       /react-intl\/locale-data$/,
-      new RegExp('^./(fr|en)$')
+      new RegExp(`^./(${supportedLanguages.join('|')})$`)
     ),
 
     function() { this.plugin('done', writeAssets(path.resolve(__dirname, 'webpack-assets.json')).bind(this)) },


### PR DESCRIPTION
Depends on #187 

_Note: This PR is opened against `error-message` for diff readability, but should be merged on `master`. Target branch should be changed once #187  is merged._

Reduces the bundle size from 2.34MB to 1.47MB (-37%) by:
- Only bundling the used locales (fr and en)
- Only bundling the used syntax coloring (python)

1.47MB is still insanely high... The best way to reduce would be to get Swagger-ui out off the bundle and load in only when visiting the `/swagger` page 