### PR TITLE
Add editorial content on variables and parameters 

### DIFF
--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -33,6 +33,7 @@
   "defaultValueParagraph": "Its {defaultValueLink} is",
   "defaultValueText": "default value",
   "referencesText": "References:",
+  "documentationText": "Documentation:",
   "aYear": "of a year",
   "aMonth": "of a month",
   "forEternity": "which is the eternity. Its value is constant over time",

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -33,6 +33,7 @@
   "defaultValueParagraph": "Sa {defaultValueLink} est",
   "defaultValueText": "valeur par défaut",
   "referencesText": "Références :",
+  "documentationText": "Documentation :",
   "aYear": "d'un an",
   "aMonth": "d'un mois",
   "forEternity": "qui est l'éternité. Sa valeur est constante dans le temps",

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -33,6 +33,11 @@ p.description {
   margin-top: 3%;
 }
 
+p.documentation {
+  margin-left: 2em;
+  white-space: pre-line;
+}
+
 span.variable-metadata {
   font-weight: bold;
 }

--- a/src/components/parameter.jsx
+++ b/src/components/parameter.jsx
@@ -31,10 +31,10 @@ class Parameter extends React.Component {
             : <em><FormattedMessage id="noDescription"/></em>
           }
           { parameter.documentation &&
-            (<span><FormattedMessage id="documentationText"/></span>)
-          }
-          { parameter.documentation &&
-            (<p className="documentation">{ parameter.documentation.trim() }</p>)
+            (<div>
+              <span><FormattedMessage id="documentationText"/></span>
+              <p className="documentation">{ parameter.documentation }</p>
+            </div>)
           }
           <div className="row">
             <div className="col-lg-8">

--- a/src/components/parameter.jsx
+++ b/src/components/parameter.jsx
@@ -30,6 +30,12 @@ class Parameter extends React.Component {
             ? <p className="description">{parameter.description}</p>
             : <em><FormattedMessage id="noDescription"/></em>
           }
+          { parameter.documentation &&
+            (<span><FormattedMessage id="documentationText"/></span>)
+          }
+          { parameter.documentation &&
+            (<p className="documentation">{ parameter.documentation.trim() }</p>)
+          }
           <div className="row">
             <div className="col-lg-8">
               {

--- a/src/components/variable.jsx
+++ b/src/components/variable.jsx
@@ -178,7 +178,7 @@ class Variable extends React.Component {
           (<span><FormattedMessage id="documentationText"/></span>)
         }
         { variable.documentation &&
-          (<p>{variable.documentation}</p>)
+          (<p className="documentation">{ variable.documentation.trim() }</p>) 
         }
         {keys(variable.formulas).length == 0 &&
           <p>

--- a/src/components/variable.jsx
+++ b/src/components/variable.jsx
@@ -178,7 +178,7 @@ class Variable extends React.Component {
           (<span><FormattedMessage id="documentationText"/></span>)
         }
         { variable.documentation &&
-          (<p className="documentation">{ variable.documentation.trim() }</p>) 
+          (<p className="documentation">{ variable.documentation.trim() }</p>)
         }
         {keys(variable.formulas).length == 0 &&
           <p>

--- a/src/components/variable.jsx
+++ b/src/components/variable.jsx
@@ -175,10 +175,10 @@ class Variable extends React.Component {
           </ul>)
         }
         { variable.documentation &&
-          (<span><FormattedMessage id="documentationText"/></span>)
-        }
-        { variable.documentation &&
-          (<p className="documentation">{ variable.documentation.trim() }</p>)
+          (<div>
+            <span><FormattedMessage id="documentationText"/></span>
+            <p className="documentation">{ variable.documentation }</p>
+          </div>)
         }
         {keys(variable.formulas).length == 0 &&
           <p>

--- a/src/components/variable.jsx
+++ b/src/components/variable.jsx
@@ -174,6 +174,12 @@ class Variable extends React.Component {
               )}
           </ul>)
         }
+        { variable.documentation &&
+          (<span><FormattedMessage id="documentationText"/></span>)
+        }
+        { variable.documentation &&
+          (<p>{variable.documentation}</p>)
+        }
         {keys(variable.formulas).length == 0 &&
           <p>
             <FormattedMessage id="noFormulaParagraph"

--- a/src/openfisca-proptypes.js
+++ b/src/openfisca-proptypes.js
@@ -10,6 +10,7 @@ const valuesShape = PropTypes.objectOf(PropTypes.oneOfType([
 export const parameterShape = PropTypes.shape({
   id: PropTypes.string,
   description: PropTypes.string,
+  documentation: PropTypes.string,
   normalizedDescription: PropTypes.string,
   values: valuesShape,
   brackets: PropTypes.objectOf(valuesShape),
@@ -19,6 +20,7 @@ export const variableShape = PropTypes.shape({
   id: PropTypes.string,
   description: PropTypes.string,
   definitionPeriod: PropTypes.string,
+  documentation: PropTypes.string,
   entity: PropTypes.string,
   formulas: PropTypes.object,
   normalizedDescription: PropTypes.string,


### PR DESCRIPTION
Fixes #124 

Add `Documentation:` field with multiline string value on variable and parameter pages.

On model's variable and parameter:
* Display `Documentation:` field when `documentation` attribute is returned by the web api. 
  * And keep new lines.
* Display nothing when `documentation` attribute doesn't exist in web api response.

Note: 
This PR ignores the following API attributes:
* parameter node `documentation` attribute
* variable formula `documentation` attribute