### PR TITLE
Update version in .env.ci from v22 to v24

### DIFF
--- a/.circleci/.env.ci
+++ b/.circleci/.env.ci
@@ -1,4 +1,4 @@
-API_URL=https://fr.openfisca.org/api/v22
+API_URL=https://fr.openfisca.org/api/v24
 CHANGELOG_URL=https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md
 
 UI_STRINGS={"en":{"countryName":"France", "search_placeholder": "smic, salaire net"},"fr":{"countryName":"France", "search_placeholder": "smic, salaire net"}}


### PR DESCRIPTION
Required by #181
Required by #194 

CircleCI builds are failing due to the non-available API v22