### PR TITLE
Match pathname before :name in routes

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Route, IndexRoute} from 'react-router'
 
+import config from './config'
 import App from './components/app'
 import HomePage from './components/pages/home'
 import SwaggerPage from './components/pages/swagger'
@@ -10,6 +11,7 @@ import CountryModelItemPage from './components/pages/country-model-item'
 export default (
   <Route path="/" component={App}>
     <IndexRoute component={HomePage} />
+    <Route path={config.pathname} component={HomePage}/>
     <Route path="swagger" component={SwaggerPage}/>
     <Route path=":name" component={CountryModelItemPage}/>
   </Route>


### PR DESCRIPTION
Fixes #199 

By matching pathname before :name in routes, we're sure it is exluded
from the :name match, hence not triggering the ParameterOrVariable
component rendering.

This is what was causing the loading div to be rendered in home page,
having as a side effect the style bug.

To test, follow #199 example.