### PR TITLE
Update Sauce Connect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,24 +17,24 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - restore_cache:
-          key: sc-4.4.12
+          key: sc-4.6.4
       - run:
           name: Install app dependencies
           command: npm install
       - run:
           name: Install saucelabs
           command: |
-            npm install saucelabs@^1.0.1 --no-save # allow sending Watai results to SauceLabs. Don't save in package.json, as this would change its checksum and mess up the cache.
+            npm install saucelabs@^1.5.0 --no-save # allow sending Watai results to SauceLabs. Don't save in package.json, as this would change its checksum and mess up the cache.
             if [ -d sc ]; then exit; fi  # sc has already been downloaded
             mkdir sc
-            wget https://saucelabs.com/downloads/sc-4.4.12-linux.tar.gz --directory-prefix sc
-            tar -xzf sc/sc-4.4.12-linux.tar.gz --directory sc
+            wget https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz --directory-prefix sc
+            tar -xzf sc/sc-4.6.4-linux.tar.gz --directory sc
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
       - save_cache:
-          key: sc-4.4.12
+          key: sc-4.6.4
           paths:
             - sc
       - run:


### PR DESCRIPTION
The used Sauce Connect library was deprecated, and the builds failing in CircleCI.

This PR fixes the issue.